### PR TITLE
fix: remove window.innerWidth setting that won't play well with googl…

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,6 @@ function addResizeCanvasListener() {
 
     // update window.innerWidth and window.visualViewport.width
     // essentially we want to push the adds out of the viewport
-    window.innerWidth = pageWidth + adsWidth;
     Object.defineProperty(window, 'visualViewport', {
       configurable: true,
       value: new Proxy(window.visualViewport, {


### PR DESCRIPTION
it will cause google ad popups to not run, which is something needed for the free version to get AI features to work by allowing viewing of the popup video ads in that special case.